### PR TITLE
fix: authenticate oauth callback test

### DIFF
--- a/tests/Unit/Actions/AuthenticateOAuthCallbackTest.php
+++ b/tests/Unit/Actions/AuthenticateOAuthCallbackTest.php
@@ -344,7 +344,7 @@ describe('Authenticate OAuth Callback Test', fn () => [
         $response = $action->authenticate($request, 'github', $socialiteUser);
 
         expect($response)->toBeInstanceOf(RedirectResponse::class)
-            ->and($response->getTargetUrl())->toBe('http://localhost/confirm?provider=github');
+            ->and($response->getTargetUrl())->toBe('http://localhost/oauth/confirm?provider=github');
     }),
     test('can handle a query exception', function () {
         /** @var SocialiteUser&MockInterface $socialiteUser */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the post-OAuth authentication redirect to point to /oauth/confirm, ensuring users land on the correct confirmation page after signing in with a provider.

* **Tests**
  * Updated test expectations to align with the new /oauth/confirm redirect path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->