### PR TITLE
fix: install command installation checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -258,69 +258,6 @@ jobs:
           DB_CONNECTION: sqlite
           DB_DATABASE: ":memory:"
 
-  test-livewire-classes-starter-kit:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        php: [ 8.2, 8.3, 8.4 ]
-        laravel: [ 12 ]
-        tester: [ phpunit, pest ]
-
-    name: Test Livewire (Class components) Starter Kit Integrations - P${{ matrix.php }} – L${{ matrix.laravel }} (${{ matrix.tester }})
-
-    steps:
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pdo, pdo_sqlite
-          ini-values: error_reporting=E_ALL
-          tools: composer:v2
-          coverage: none
-
-      - name: Setup Project
-        run: |
-          composer create-project laravel/livewire-starter-kit:dev-components example-app
-
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          path: 'laravel-socialite-ui'
-
-      - name: Install Pest
-        working-directory: ./example-app
-        if: ${{ matrix.tester == 'pest' }}
-        run: |
-          composer remove phpunit/phpunit --dev --no-update
-          composer require pestphp/pest pestphp/pest-plugin-laravel --no-update --dev
-          composer update --prefer-dist --no-interaction
-          ./vendor/bin/pest --init
-
-      - name: Install Socialite UI
-        working-directory: ./example-app
-        run: |
-          composer require laravel-uis/socialite-ui:@dev --no-interaction --no-update
-          composer config repositories.laravel-socialite-ui '{"type": "path", "url": "./../laravel-socialite-ui"}' --file composer.json
-          composer update "laravel-uis/socialite-ui" -W --prefer-dist --no-interaction
-          composer update --prefer-dist --no-interaction
-          php artisan socialite-ui:install
-
-      - name: Install NPM dependencies
-        working-directory: ./example-app
-        run: npm i
-
-      - name: Compile assets
-        working-directory: ./example-app
-        run: npm run build
-
-      - name: Execute tests
-        working-directory: ./example-app
-        run: ./vendor/bin/${{ matrix.tester }}
-        env:
-          DB_CONNECTION: sqlite
-          DB_DATABASE: ":memory:"
-
   check:
     if: always()
     needs:
@@ -329,7 +266,6 @@ jobs:
       - test-react-starter-kit
       - test-vue-starter-kit
       - test-livewire-starter-kit
-      - test-livewire-classes-starter-kit
     runs-on: ubuntu-latest
 
     steps:

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -39,17 +39,17 @@ class InstallCommand extends Command implements PromptsForMissingInput
      */
     public function handle(): ?int
     {
-        //        if ($this->alreadyInstalled()) {
-        //            warning('Socialite UI is already installed.');
-        //
-        //            return self::FAILURE;
-        //        }
-        //
-        //        if ($this->conflictsWithWorkOS()) {
-        //            warning('Socialite UI conflicts with WorkOS. Please uninstall WorkOS before installing Socialite UI.');
-        //
-        //            return self::FAILURE;
-        //        }
+        if ($this->alreadyInstalled()) {
+           warning('Socialite UI is already installed.');
+        
+           return self::FAILURE;
+        }
+        
+        if ($this->conflictsWithWorkOS()) {
+           warning('Socialite UI conflicts with WorkOS. Please uninstall WorkOS before installing Socialite UI.');
+        
+           return self::FAILURE;
+        }
 
         $this->installFor(
             $stack = $this->stack(),

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -40,15 +40,15 @@ class InstallCommand extends Command implements PromptsForMissingInput
     public function handle(): ?int
     {
         if ($this->alreadyInstalled()) {
-           warning('Socialite UI is already installed.');
-        
-           return self::FAILURE;
+            warning('Socialite UI is already installed.');
+
+            return self::FAILURE;
         }
-        
+
         if ($this->conflictsWithWorkOS()) {
-           warning('Socialite UI conflicts with WorkOS. Please uninstall WorkOS before installing Socialite UI.');
-        
-           return self::FAILURE;
+            warning('Socialite UI conflicts with WorkOS. Please uninstall WorkOS before installing Socialite UI.');
+
+            return self::FAILURE;
         }
 
         $this->installFor(
@@ -93,18 +93,22 @@ class InstallCommand extends Command implements PromptsForMissingInput
         ]);
         ServiceProvider::addProviderToBootstrapFile('App\Providers\SocialiteUiServiceProvider');
 
-        if (in_array($stack, ['react', 'vue'])) {
-            $this->installInertia();
+        $callback = match ($stack) {
+            'react' => function (): void {
+                $this->installInertia();
+                $this->installReact();
+            },
+            'vue' => function (): void {
+                    $this->installInertia();
+                    $this->installVue();
+            },
+            'livewire' => function (): void {
+                $this->installLivewire();
+            },
+            default => throw new \InvalidArgumentException("Unsupported stack: $stack"),
+        };
 
-            match ($stack) {
-                'react' => $this->installReact(),
-                'vue' => $this->installVue(),
-            };
-
-            return;
-        }
-
-        $this->installLivewire($stack);
+        $callback();
     }
 
     /**
@@ -243,7 +247,7 @@ class InstallCommand extends Command implements PromptsForMissingInput
     /**
      * Install for the Livewire starter kit.
      */
-    protected function installLivewire(string $livewire): void
+    protected function installLivewire(): void
     {
         $this->ensureDirectoriesExist([
             resource_path('views/components/layouts/app'),
@@ -255,51 +259,40 @@ class InstallCommand extends Command implements PromptsForMissingInput
 
         // Layouts
         $this->copyFiles([
-            __DIR__."/../../stubs/$livewire/resources/views/components/layouts/app/sidebar.blade.php" => resource_path('views/components/layouts/app/sidebar.blade.php'),
-            __DIR__."/../../stubs/$livewire/resources/views/components/settings/layout.blade.php" => resource_path('views/components/settings/layout.blade.php'),
+            __DIR__.'/../../stubs/livewire/resources/views/components/layouts/app/sidebar.blade.php' => resource_path('views/components/layouts/app/sidebar.blade.php'),
+            __DIR__.'/../../stubs/livewire/resources/views/components/settings/layout.blade.php' => resource_path('views/components/settings/layout.blade.php'),
         ]);
 
         // Icons
-        (new Filesystem)->copyDirectory(__DIR__."/../../stubs/$livewire/resources/views/components/socialite-provider-icons", resource_path('views/components/socialite-provider-icons'));
+        (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/livewire/resources/views/components/socialite-provider-icons', resource_path('views/components/socialite-provider-icons'));
 
         // Components
         $this->copyFiles([
-            __DIR__."/../../stubs/$livewire/resources/views/components/socialite.blade.php" => resource_path('views/components/socialite.blade.php'),
-            __DIR__."/../../stubs/$livewire/resources/views/components/socialite-provider-icon.blade.php" => resource_path('views/components/socialite-provider-icon.blade.php'),
+            __DIR__.'/../../stubs/livewire/resources/views/components/socialite.blade.php' => resource_path('views/components/socialite.blade.php'),
+            __DIR__.'/../../stubs/livewire/resources/views/components/socialite-provider-icon.blade.php' => resource_path('views/components/socialite-provider-icon.blade.php'),
         ]);
 
         // Auth Views
         $this->copyFiles([
-            __DIR__."/../../stubs/$livewire/resources/views/livewire/auth/confirm-link-account.blade.php" => resource_path('views/livewire/auth/confirm-link-account.blade.php'),
-            __DIR__."/../../stubs/$livewire/resources/views/livewire/auth/login.blade.php" => resource_path('views/livewire/auth/login.blade.php'),
-            __DIR__."/../../stubs/$livewire/resources/views/livewire/auth/register.blade.php" => resource_path('views/livewire/auth/register.blade.php'),
+            __DIR__.'/../../stubs/livewire/resources/views/livewire/auth/confirm-link-account.blade.php' => resource_path('views/livewire/auth/confirm-link-account.blade.php'),
+            __DIR__.'/../../stubs/livewire/resources/views/livewire/auth/login.blade.php' => resource_path('views/livewire/auth/login.blade.php'),
+            __DIR__.'/../../stubs/livewire/resources/views/livewire/auth/register.blade.php' => resource_path('views/livewire/auth/register.blade.php'),
         ]);
 
         // Settings Views
         $this->copyFiles([
-            __DIR__."/../../stubs/$livewire/resources/views/livewire/settings/delete-user-form.blade.php" => resource_path('views/livewire/settings/delete-user-form.blade.php'),
-            __DIR__."/../../stubs/$livewire/resources/views/livewire/settings/linked-account.blade.php" => resource_path('views/livewire/settings/linked-account.blade.php'),
-            __DIR__."/../../stubs/$livewire/resources/views/livewire/settings/linked-accounts.blade.php" => resource_path('views/livewire/settings/linked-accounts.blade.php'),
-            __DIR__."/../../stubs/$livewire/resources/views/livewire/settings/password.blade.php" => resource_path('views/livewire/settings/password.blade.php'),
-            __DIR__."/../../stubs/$livewire/resources/views/livewire/settings/update-avatar.blade.php" => resource_path('views/livewire/settings/update-avatar.blade.php'),
+            __DIR__.'/../../stubs/livewire/resources/views/livewire/settings/delete-user-form.blade.php' => resource_path('views/livewire/settings/delete-user-form.blade.php'),
+            __DIR__.'/../../stubs/livewire/resources/views/livewire/settings/linked-account.blade.php' => resource_path('views/livewire/settings/linked-account.blade.php'),
+            __DIR__.'/../../stubs/livewire/resources/views/livewire/settings/linked-accounts.blade.php' => resource_path('views/livewire/settings/linked-accounts.blade.php'),
+            __DIR__.'/../../stubs/livewire/resources/views/livewire/settings/password.blade.php' => resource_path('views/livewire/settings/password.blade.php'),
+            __DIR__.'/../../stubs/livewire/resources/views/livewire/settings/update-avatar.blade.php' => resource_path('views/livewire/settings/update-avatar.blade.php'),
         ]);
 
         // Routes
         $this->copyFiles([
-            __DIR__."/../../stubs/$livewire/routes/auth.php" => base_path('routes/auth.php'),
-            __DIR__."/../../stubs/$livewire/routes/web.php" => base_path('routes/web.php'),
+            __DIR__.'/../../stubs/livewire/routes/auth.php' => base_path('routes/auth.php'),
+            __DIR__.'/../../stubs/livewire/routes/web.php' => base_path('routes/web.php'),
         ]);
-
-        if ($livewire === 'livewire-class-components') {
-            $this->copyFiles([
-                __DIR__."/../../stubs/$livewire/app/Livewire/Auth/ConfirmLinkAccount.php" => app_path('Livewire/Auth/ConfirmLinkAccount.php'),
-                __DIR__."/../../stubs/$livewire/app/Livewire/Settings/DeleteUserForm.php" => app_path('Livewire/Settings/DeleteUserForm.php'),
-                __DIR__."/../../stubs/$livewire/app/Livewire/Settings/LinkedAccount.php" => app_path('Livewire/Settings/LinkedAccount.php'),
-                __DIR__."/../../stubs/$livewire/app/Livewire/Settings/LinkedAccounts.php" => app_path('Livewire/Settings/LinkedAccounts.php'),
-                __DIR__."/../../stubs/$livewire/app/Livewire/Settings/Password.php" => app_path('Livewire/Settings/Password.php'),
-                __DIR__."/../../stubs/$livewire/app/Livewire/Settings/UpdateAvatar.php" => app_path('Livewire/Settings/UpdateAvatar.php'),
-            ]);
-        }
     }
 
     /**
@@ -333,35 +326,20 @@ class InstallCommand extends Command implements PromptsForMissingInput
      */
     protected function stack(): string
     {
-        $stack = $this->detectStack();
-
-        if (! $stack) {
-            $stack = (string) select(
-                label: 'Which starter kit are you using?',
-                options: [
-                    'react' => 'React Starter Kit',
-                    'vue' => 'Vue Starter Kit',
-                    'livewire' => 'Livewire Starter Kit',
-                ],
-            );
-
-            if ($stack !== 'livewire') {
-                return $stack;
-            }
-
-            return confirm(
-                label: 'Would you like to use Laravel Volt?',
-                default: true,
-            ) ? 'livewire' : 'livewire-class-components';
-        }
-
-        return $stack;
+        return $this->detectStack() ?? (string) select(
+            label: 'Which starter kit are you using?',
+            options: [
+                'react' => 'React Starter Kit',
+                'vue' => 'Vue Starter Kit',
+                'livewire' => 'Livewire Starter Kit',
+            ],
+        );
     }
 
     /**
      * Detect the stack that is installed.
      */
-    protected function detectStack(): string
+    protected function detectStack(): ?string
     {
         if (file_exists(resource_path('js/app.tsx'))) {
             return 'react';
@@ -371,7 +349,7 @@ class InstallCommand extends Command implements PromptsForMissingInput
             return 'vue';
         }
 
-        return class_exists('App\Livewire\Settings\Profile') ? 'livewire-class-components' : 'livewire';
+        return class_exists('App\Livewire\Settings\Profile') ? 'livewire' : null;
     }
 
     /**

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -349,7 +349,7 @@ class InstallCommand extends Command implements PromptsForMissingInput
             return 'vue';
         }
 
-        return class_exists('App\Livewire\Settings\Profile') ? 'livewire' : null;
+        return class_exists('App\Providers\VoltServiceProvider') ? 'livewire' : null;
     }
 
     /**


### PR DESCRIPTION
## Summary <!-- tl;dr one line summary of this PR -->

[//]: # (copilot:summary)
This pull request fix the install command so that the initial checks for being already installed, or conflicting with workOS are re-added.

## Explanation  <!-- A more in depth explanation of the approach, reasoning, questions etc... -->

[//]: # (copilot:walkthrough)
<!-- List the changes and why they were made -->

## Checklist <!-- Put an `x` in all the boxes that apply. -->

- [ ] I've read this template
- [ ] I've checked reviewed this PR myself, ensuring consistency and quality with the rest of the project
- [ ] I've given a good reason as to why this PR exposes new / removes existing user data


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Installation now prevents re-install attempts and halts on WorkOS conflicts with clear warnings.

* **Improvements**
  * Streamlined stack detection and user prompting for more reliable behavior.
  * Unified stack installation flow with clearer error for unsupported stacks.
  * Simplified Livewire installation path for a smoother setup experience.

* **Chores**
  * Removed CI job for the legacy Livewire starter kit.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->