### PR TITLE
Fix linked-accounts.destroy route parameter in React and Vue stubs

### DIFF
--- a/stubs/react/resources/js/components/linked-account.tsx
+++ b/stubs/react/resources/js/components/linked-account.tsx
@@ -46,7 +46,7 @@ export default function LinkedAccount({ socialAccount, socialiteUi }: LinkedAcco
     const unlinkAccount: FormEventHandler = (e) => {
         e.preventDefault();
 
-        destroy(route('linked-accounts.destroy', { socialAccount }), {
+        destroy(route('linked-accounts.destroy', { account: socialAccount.id }), {
             preserveScroll: true,
             onSuccess: () => closeModal(),
             onError: () => passwordInput.current?.focus(),

--- a/stubs/vue/resources/js/components/LinkedAccount.vue
+++ b/stubs/vue/resources/js/components/LinkedAccount.vue
@@ -46,7 +46,7 @@ const unlinkAccountForm = useForm({
 const unlinkAccount = (e: Event) => {
    e.preventDefault();
 
-   unlinkAccountForm.delete(route('linked-accounts.destroy', { socialAccount }), {
+   unlinkAccountForm.delete(route('linked-accounts.destroy', { account: socialAccount.id }), {
       preserveScroll: true,
       onSuccess: () => closeModal(),
       onError: () => passwordInput.value?.focus(),


### PR DESCRIPTION
### Motivation
- Resolve Ziggy error reported in issue #5 where the unlink action failed because the named route `linked-accounts.destroy` required an `account` parameter but received `{ socialAccount }` instead.

### Description
- Update the route call in `stubs/react/resources/js/components/linked-account.tsx` and `stubs/vue/resources/js/components/LinkedAccount.vue` to pass the ID with `route('linked-accounts.destroy', { account: socialAccount.id })` instead of `{ socialAccount }`.

### Testing
- Ran `rg -n "linked-accounts.destroy', \{ socialAccount \}"` to confirm no remaining incorrect calls and ran `git diff --check` to validate the patch formatting, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca99cb72308321830b1f063af3b3a7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed linked account unlink functionality to ensure proper account removal request processing in both React and Vue versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->