### PR TITLE
fix(ci): pin starter-kit versions to ^1.0 in integration workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Setup Project
         run: |
-          composer create-project laravel/react-starter-kit example-app
+          composer create-project "laravel/react-starter-kit:^1.0" example-app
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -155,7 +155,7 @@ jobs:
 
       - name: Setup Project
         run: |
-          composer create-project laravel/vue-starter-kit example-app
+          composer create-project "laravel/vue-starter-kit:^1.0" example-app
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -218,7 +218,7 @@ jobs:
 
       - name: Setup Project
         run: |
-          composer create-project laravel/livewire-starter-kit example-app
+          composer create-project "laravel/livewire-starter-kit:^1.0" example-app
 
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
### Motivation
- Prevent CI breakage on the 1.x branch by avoiding accidental upgrades to incompatible major releases of the starter-kits used in integration tests.

### Description
- Updated `.github/workflows/tests.yml` to pin the `composer create-project` invocations for `laravel/react-starter-kit`, `laravel/vue-starter-kit`, and `laravel/livewire-starter-kit` to `^1.0`.
- This change scopes the integration jobs to starter-kit 1.x releases so upstream major bumps do not cause workflow failures.

### Testing
- Verified the modified workflow YAML parses successfully with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/tests.yml"); puts "YAML_OK"'`, which returned `YAML_OK`.
- A `python`-based YAML check failed because `pyyaml` was not available in the environment.
- Attempted `composer update` to validate dependency operations but it failed due to network/Packagist access errors (`CONNECT tunnel failed, response 403`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca9b4243b4832181f8928f68ee22da)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version constraints in CI setup for starter kit integration tests to ensure consistent package resolution across React, Vue, and Livewire environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->