### PR TITLE
Fix Volt confirm-link-account mount logic in Livewire stubs

### DIFF
--- a/stubs/livewire/resources/views/livewire/auth/confirm-link-account.blade.php
+++ b/stubs/livewire/resources/views/livewire/auth/confirm-link-account.blade.php
@@ -1,16 +1,17 @@
 <?php
 
-use Socialite\Socialite;
+use SocialiteUi\Enums\Provider;
 use Livewire\Attributes\Layout;
 use Livewire\Volt\Component;
 
 new #[Layout('components.layouts.auth')]
 class extends Component {
     public string $provider = '';
+    public string $password = '';
 
     public function mount(): void
     {
-        $this->provider = Socialite::provider(request()->string('provider'))->name;
+        $this->provider = request()->enum('provider', Provider::class)?->name ?? request()->string('provider')->toString();
     }
 }; ?>
 

--- a/stubs/livewire/resources/views/livewire/auth/confirm-link-account.blade.php
+++ b/stubs/livewire/resources/views/livewire/auth/confirm-link-account.blade.php
@@ -17,8 +17,8 @@ class extends Component {
 
 <div class="flex flex-col gap-6">
     <x-auth-header
-            :title="__('Link :provider', ['provider' => $provider])"
-            :description="__('Please confirm your password before linking your :provider account.', ['provider' => $provider])"
+            :title="__('Link :provider', ['provider' => Providers::name($provider)])"
+            :description="__('Please confirm your password before linking your :provider account.', ['provider' => Providers::name($provider)])"
     />
 
     <form method="post" action="{{ route('oauth.confirm', ['provider' => $provider]) }}" class="flex flex-col gap-6">


### PR DESCRIPTION
### Motivation
- The Volt (Livewire) `confirm-link-account` stub used an incorrect import and provider resolution that broke starter-kit installs and CI, and the component lacked a declared `password` property used by `wire:model`.

### Description
- Replace the invalid `Socialite\Socialite` import with `SocialiteUi\Enums\Provider`, add a `password` property to the Volt component, and resolve the provider using `request()->enum(...)?->name` with a string fallback in `stubs/livewire/resources/views/livewire/auth/confirm-link-account.blade.php`.

### Testing
- Ran `php -l stubs/livewire/resources/views/livewire/auth/confirm-link-account.blade.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb8d0398088321aff2f1193dc5b338)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account-linking flow to more reliably recognize and display the selected provider.
  * Added robust fallback for provider selection to prevent mismatches during confirmation.
  * Restored password field binding in the account confirmation form for consistent input handling and smoother submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->